### PR TITLE
Add QTH Marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,17 @@
 				var mapCanvas = document.getElementById('map-canvas');
 				toggleElement(mapCanvas, sender);
 			}
+                        // If a lat/long is specified in the query string, try to use it as the
+                        // QTH/Operating location for the log file.
+                        // This allows for semi-obvious location-range mapping
+                        // ex: qth=22.303940,114.170372 will place a yellow marker at 22.3, 114.1 on the map
+                        var qth = getQueryVariable('qth');
+                        if (qth !== null) {
+                                createQTHMarker(qth, "Home QTH")
+                                //createQTHMarker(40.786, -73.961, "Home QTH")
+                        }
+
+
 		</script>
 	</body>
 </html>

--- a/qso-mapper.css
+++ b/qso-mapper.css
@@ -52,6 +52,11 @@ body {
 	width: 100%
 }
 
+
+.qth h1 {
+	font-size: 2rem;
+}
+
 .qso h1 {
 	font-size: 2rem;
 }

--- a/qso-mapper.js
+++ b/qso-mapper.js
@@ -212,6 +212,45 @@ function removeQso(qso) {
 	}
 }
 
+/* createQTHMarker - create a marker on the map at the given position.
+ *
+ * Set up a marker on the map for operating QTH and corresponding pop-up for
+ * when the marker is selected.
+ */
+function createQTHMarker(latlong, popupText) {
+        // To use a smaller marker, use something like this...
+        var blueMarkerSmall = L.icon({
+                iconUrl: 'icons/ylw-blank.png',
+                iconSize:     [32, 32], // size of the icon
+                iconAnchor:   [16, 32], // point of the icon which will correspond to marker's location
+                popupAnchor:  [0, -16] // point from which the popup should open relative to the iconAnchor
+        });
+        var [latitude, longitude] = latlong.split(',');
+        var marker = L.marker([latitude, longitude], {icon: blueMarkerSmall, zIndexOffset: 1000});
+
+        marker.addTo(_markerFeatureGroup)
+                .bindPopup(popupText);
+
+        _markers.push(marker);
+        return marker;
+}
+
+/* addMarkerforQth - add a marker to the map for a given operating location */
+function addMarkerForQth(qth) {
+        var latlon = latLonForQso(qth);
+        if (latlon == null) {
+                return null;
+        }
+
+        var [latitude, longitude] = latlon;
+        var popupText = '<div class="qth">' +
+                '<h1>' + qth.call + '</h1><hr/>' +
+                '</div>';
+
+        marker = createMarker(latitude, longitude, popupText);
+        return marker;
+}
+
 /* addMarkerForQso - add a marker to the map for a given QSO */
 function addMarkerForQso(qso) {
 	var latlon = latLonForQso(qso);


### PR DESCRIPTION
Adds a semi-hidden feature to display the QTH of a given log.

![image](https://github.com/user-attachments/assets/0f2e6bca-f2d8-4394-9dc3-944eec9ba766)


By adding `?qth=lat,long` to the URL, a yellow marker will be displayed on top of other pins showing the operating QTH.

This feature could be more automatically utilized in a future code change by enabling/processing the `<my_gridsquare>` or `<my_lat>`/`<my_long>` fields which are generally available in the ADIF spec (present since ADIF v3.0.6, circa 2017)

A future change could also add polylines between the QTH and a contact, though this may need to be done carefully to prevent the graph from becoming too "noisy" or "busy".